### PR TITLE
Use `defmacro/2` to define a guard

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,49 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Elixir CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    name: OTP ${{matrix.pair.otp}} / Elixir ${{matrix.pair.elixir}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pair:
+              otp: 25
+              elixir: 1.14
+          - pair:
+              otp: 27
+              elixir: 1.18
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
+      - name: Dependencies Cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+      - name: Install Dependencies
+        run: mix deps.get
+      - name: Test
+        run: mix test

--- a/lib/unicode_guards.ex
+++ b/lib/unicode_guards.ex
@@ -155,8 +155,11 @@ defmodule Unicode.Guards do
 
   @doc false
   # Replaced by `is_graph/1`.
-  defguard is_visible(codepoint)
-           when is_integer(codepoint) and match?(codepoint, "[[:visible:]]")
+  defmacro is_visible(codepoint) do
+    quote generated: true, location: :keep do
+      is_integer(unquote(codepoint)) and match?(unquote(codepoint), "[[:visible:]]")
+    end
+  end
 
   @doc """
   Guards whether a UTF8 codepoint is a graphic character.
@@ -166,8 +169,11 @@ defmodule Unicode.Guards do
   non-space, non-control and non-surrogate.
 
   """
-  defguard is_graph(codepoint)
-           when is_integer(codepoint) and match?(codepoint, "[[:graph:]]")
+  defmacro is_graph(codepoint) do
+    quote generated: true, location: :keep do
+      is_integer(unquote(codepoint)) and match?(unquote(codepoint), "[[:graph:]]")
+    end
+  end
 
   @doc """
   Guards whether a UTF8 codepoint is a space character.
@@ -187,6 +193,9 @@ defmodule Unicode.Guards do
   `[:graph:]` set and the `[:blank:]` set.
 
   """
-  defguard is_print(codepoint)
-           when is_integer(codepoint) and match?(codepoint, "[[:print:]]")
+  defmacro is_print(codepoint) do
+    quote generated: true, location: :keep do
+      is_integer(unquote(codepoint)) and match?(unquote(codepoint), "[[:print:]]")
+    end
+  end
 end


### PR DESCRIPTION
The solution that seems to fix the exceeded guard stack is to use plain old good `defmacro/2` instead of `defguard/2`. This should hopefully fix #7

This PR obsoletes #8 